### PR TITLE
[DO NOT MERGE] Adds experiments to simple app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ import static org.gradle.api.tasks.testing.TestResult.ResultType
 
 buildscript {
     repositories {
+        mavenLocal()
         if (project.hasProperty("googleRepo")) {
             maven {
                 name "Google"
@@ -48,6 +49,7 @@ plugins {
 
 allprojects {
     repositories {
+        mavenLocal()
         if (project.hasProperty("googleRepo")) {
             maven {
                 name "Google"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,6 +7,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     jcenter()
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
 
     const val mozilla_appservices = "61.0.10"
 
-    const val mozilla_glean = "31.4.1"
+    const val mozilla_glean = "31.4.1-TESTING29"
 
     const val material = "1.1.0"
     const val nearby = "17.0.0"

--- a/components/browser/engine-gecko-beta/build.gradle
+++ b/components/browser/engine-gecko-beta/build.gradle
@@ -4,6 +4,7 @@
 
 buildscript {
     repositories {
+        mavenLocal()
         maven {
             url "https://maven.mozilla.org/maven2"
         }

--- a/components/browser/engine-gecko-nightly/build.gradle
+++ b/components/browser/engine-gecko-nightly/build.gradle
@@ -4,6 +4,7 @@
 
 buildscript {
     repositories {
+        mavenLocal()
         maven {
             url "https://maven.mozilla.org/maven2"
         }

--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -4,6 +4,7 @@
 
 buildscript {
     repositories {
+        mavenLocal()
         maven {
             url "https://maven.mozilla.org/maven2"
         }

--- a/components/lib/crash/build.gradle
+++ b/components/lib/crash/build.gradle
@@ -4,6 +4,7 @@
 
 buildscript {
     repositories {
+        mavenLocal()
         maven {
             url "https://maven.mozilla.org/maven2"
         }

--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -46,8 +46,9 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
     implementation Dependencies.androidx_work_runtime
-    
-    api GLEAN_LIBRARY
+    api (GLEAN_LIBRARY) {
+        exclude group: 'org.mozilla.components', module: 'concept-fetch'
+    }
 
     // So consumers can set a HTTP client.
     api project(':concept-fetch')

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Experiments.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Experiments.kt
@@ -1,0 +1,17 @@
+package mozilla.components.service.glean
+
+import android.content.Context
+import kotlinx.coroutines.*
+import mozilla.telemetry.glean.Experiments as ExperimentsCore
+
+object Experiments {
+    private var inner: ExperimentsCore = ExperimentsCore
+    private val job = SupervisorJob()
+    private val scope = CoroutineScope(Dispatchers.IO) + job
+    fun initialize(applicationContext: Context, dbPath: String) {
+        inner.initialize(applicationContext, dbPath)
+    }
+    fun getBranch(experimentName: String): String {
+        return inner.getBranch(experimentName)
+    }
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/HttpConfig.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/HttpConfig.kt
@@ -1,0 +1,24 @@
+package mozilla.components.service.glean
+
+
+import mozilla.components.concept.fetch.Client
+import mozilla.telemetry.glean.RustHttpConfig as HttpConfig
+
+/**
+ * An object allowing configuring the HTTP client used by Rust code.
+ */
+object RustHttpConfig {
+
+    /**
+     * Set the HTTP client to be used by all Rust code.
+     *
+     * The `Lazy`'s value is not read until the first request is made.
+     *
+     * This must be called
+     * - after initializing a megazord for users using a custom megazord build.
+     * - before any other calls into application-services rust code which make HTTP requests.
+     */
+    fun setClient(c: Lazy<Client>) {
+        HttpConfig.setClient(c)
+    }
+}

--- a/components/support/migration/build.gradle
+++ b/components/support/migration/build.gradle
@@ -4,6 +4,7 @@
 
 buildscript {
     repositories {
+        mavenLocal()
         maven {
             url "https://maven.mozilla.org/maven2"
         }

--- a/components/support/sync-telemetry/build.gradle
+++ b/components/support/sync-telemetry/build.gradle
@@ -4,6 +4,7 @@
 
 buildscript {
     repositories {
+        mavenLocal()
         maven {
             url "https://maven.mozilla.org/maven2"
         }

--- a/components/tooling/glean-gradle-plugin/build.gradle
+++ b/components/tooling/glean-gradle-plugin/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
@@ -67,6 +68,7 @@ publishing {
     }
 
     repositories {
+        mavenLocal()
         maven {
             url = "$buildDir/maven"
         }

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -4,6 +4,7 @@
 
 buildscript {
     repositories {
+        mavenLocal()
         maven {
             url "https://maven.mozilla.org/maven2"
         }

--- a/samples/glean/samples-glean-library/build.gradle
+++ b/samples/glean/samples-glean-library/build.gradle
@@ -4,6 +4,7 @@
 
 buildscript {
     repositories {
+        mavenLocal()
         maven {
             url "https://maven.mozilla.org/maven2"
         }

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
@@ -6,51 +6,66 @@ package org.mozilla.samples.glean
 
 import android.app.Application
 import android.content.Intent
+import kotlinx.coroutines.*
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.experiments.Configuration as ExperimentsConfig
 import mozilla.components.service.glean.Glean
+import mozilla.components.service.glean.Experiments as Exp
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.net.ConceptFetchHttpUploader
 import mozilla.components.service.experiments.Experiments
+import mozilla.components.service.glean.RustHttpConfig
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.sink.AndroidLogSink
 import org.mozilla.samples.glean.GleanMetrics.Basic
 import org.mozilla.samples.glean.GleanMetrics.Test
 import org.mozilla.samples.glean.GleanMetrics.Custom
 import org.mozilla.samples.glean.GleanMetrics.Pings
+import kotlin.coroutines.CoroutineContext
+
 
 class GleanApplication : Application() {
 
     override fun onCreate() {
-        super.onCreate()
+            super.onCreate()
+            // We want the log messages of all builds to go to Android logcat
+            Log.addSink(AndroidLogSink())
 
-        // We want the log messages of all builds to go to Android logcat
-        Log.addSink(AndroidLogSink())
+            // Register the sample application's custom pings.
+            Glean.registerPings(Pings)
 
-        // Register the sample application's custom pings.
-        Glean.registerPings(Pings)
+            // Initialize the Glean library. Ideally, this is the first thing that
+            // must be done right after enabling logging.
+            val client by lazy { HttpURLConnectionClient() }
+            val httpClient = ConceptFetchHttpUploader.fromClient(client)
+            val config = Configuration(httpClient = httpClient)
+            Glean.initialize(applicationContext, uploadEnabled = true, configuration = config)
+            RustHttpConfig.setClient(lazy { HttpURLConnectionClient() })
+            Thread {
+                GlobalScope.launch {
+                    var exp = mozilla.components.service.glean.Experiments
+                    exp.initialize(applicationContext, applicationContext.dataDir.path)
+                    val res = exp.getBranch("button-color")
+                    println(res)
+                    //TODO
+                    // Send an enrolled event for the experiment
+                    // Send a saw button-color button. AKA "User saw some branch of the experiment"
+                }
+            }.start()
+            // Initialize the Experiments library and pass in the callback that will generate a
+            // broadcast Intent to signal the application that experiments have been updated. This is
+            // only relevant to the experiments library, aside from recording the experiment in Glean.
+            Experiments.initialize(applicationContext, ExperimentsConfig(httpClient = client)) {
+                val intent = Intent()
+                intent.action = "org.mozilla.samples.glean.experiments.updated"
+                sendBroadcast(intent)
+            }
 
-        // Initialize the Glean library. Ideally, this is the first thing that
-        // must be done right after enabling logging.
-        val client by lazy { HttpURLConnectionClient() }
-        val httpClient = ConceptFetchHttpUploader.fromClient(client)
-        val config = Configuration(httpClient = httpClient)
-        Glean.initialize(applicationContext, uploadEnabled = true, configuration = config)
+            Test.timespan.start()
 
-        // Initialize the Experiments library and pass in the callback that will generate a
-        // broadcast Intent to signal the application that experiments have been updated. This is
-        // only relevant to the experiments library, aside from recording the experiment in Glean.
-        Experiments.initialize(applicationContext, ExperimentsConfig(httpClient = client)) {
-            val intent = Intent()
-            intent.action = "org.mozilla.samples.glean.experiments.updated"
-            sendBroadcast(intent)
+            Custom.counter.add()
+
+            // Set a sample value for a metric.
+            Basic.os.set("Android")
         }
-
-        Test.timespan.start()
-
-        Custom.counter.add()
-
-        // Set a sample value for a metric.
-        Basic.os.set("Android")
     }
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ import org.yaml.snakeyaml.Yaml
 
 buildscript {
     repositories {
+        mavenLocal()
         jcenter()
     }
 


### PR DESCRIPTION
This is meant to be pulled for local testing of the experiments prototype in glean. 
You'll have to first publish glean to maven local.

## Publishing Glean with prototype to mavenLocal
First, clone `a-s-dev`'s Glean fork
```
git clone git@github.com:a-s-dev/glean.git && cd glean
```

Then, switch to the `test-experiments-do-not-merge` branch:
```
git checkout test-experiments-do-not-merge
``` 

Then publish glean to mavenLocal

```
./gradlew publishToMavenLocal
```

## Running experiments API from Android Components

Make sure you are on this branch (`test-experiments-do-not-merge`), on the `a-s-dev` fork of android components. 

Then you can run/debug the `samples-glean` app in AC and it would be calling into the [rust-experimenter](https://github.com/a-s-dev/rust-experimenter/pull/1) in `GleanApplication.kt`. So far it initializes the components, which uses viaduct to request experiment information, and it persists that information for the next time you run it. 